### PR TITLE
Add SSH Authentication Fails Risk Description

### DIFF
--- a/Risks/SSH_Authentication_Fails.md
+++ b/Risks/SSH_Authentication_Fails.md
@@ -1,0 +1,36 @@
+### Risk Description
+
+**Title:** SSH Authentication Fails for GIT Source Authentication
+
+**Description:** The project relies on GIT for source control management. SSH authentication is currently failing, which prevents developers from accessing the repository. This issue can lead to delays in development, inability to push or pull code changes, and overall disruption in the workflow. The recommended alternative is to use HTTPS with username/password for authentication, but this may introduce security concerns and additional overhead for managing credentials.
+
+**Category:** Technology
+
+**Trigger:** Infrastructure
+
+**Likelihood:** High
+
+**Impact:** High
+
+**Responsible Person:** DevOps Engineer
+
+**Treatment/Maintenance Plan:**
+1. Investigate the root cause of SSH authentication failure.
+2. Implement a temporary switch to HTTPS with username/password.
+3. Ensure secure storage and management of credentials.
+4. Monitor the system for any further authentication issues.
+5. Plan for a long-term solution to restore SSH authentication.
+
+**Risk Strategy:** Mitigate
+
+**Mitigation Plan Actions:**
+1. Conduct a thorough investigation to identify the cause of the SSH failure.
+2. Apply necessary patches or updates to the SSH configuration.
+3. Provide training to the team on using HTTPS with username/password securely.
+4. Implement multi-factor authentication (MFA) for added security.
+
+**Contingency Plan Actions:**
+1. Maintain regular backups of the repository.
+2. Set up an alternative repository access method.
+3. Document the process for switching authentication methods.
+4. Communicate with the team about the issue and provide support as needed.


### PR DESCRIPTION
Added detailed risk description for the issue of SSH authentication failing for GIT source authentication. This includes risk category, trigger, likelihood, impact, responsible person, treatment/maintenance plan, risk strategy, mitigation plan actions, and contingency plan actions.