### PR TITLE
Add risk description for 'New collections not created post-import'

### DIFF
--- a/New_collections_not_created_post_import.md
+++ b/New_collections_not_created_post_import.md
@@ -1,0 +1,37 @@
+### Risk Description
+
+**Title:** New collections are not created under the Collections section post-import.
+
+**Detailed Risk Description:** After importing data, there is a risk that new collections may not be created under the Collections section. This could lead to incomplete data representation and hinder the ability to access and manage the imported data effectively. The issue may arise due to various reasons such as import process failures, data format inconsistencies, or software bugs.
+
+**Risk Category:** Quality
+
+**Risk Trigger:** Process and Practices
+
+**Risk Likelihood:** Middle
+
+**Risk Impact:** High
+
+**Responsible Person:** Data Import Manager
+
+**Treatment/Maintenance Plan:**
+1. Conduct thorough testing of the import process to identify potential issues.
+2. Implement validation checks to ensure data format consistency before import.
+3. Monitor the import process and log any errors or warnings.
+4. Provide training to the team on best practices for data import.
+5. Regularly update the import software to the latest version to avoid known bugs.
+
+**Risk Strategy:** Mitigate
+
+**Mitigation Plan Actions:**
+1. Develop automated tests to verify the creation of collections post-import.
+2. Create a checklist for data format validation before import.
+3. Set up monitoring tools to track the import process in real-time.
+4. Schedule regular training sessions for the team on data import procedures.
+5. Keep the import software updated and apply patches as needed.
+
+**Contingency Plan Actions:**
+1. Have a manual process in place to create collections if the automated process fails.
+2. Maintain a backup of the data before import to allow for re-import if necessary.
+3. Establish a support team to address import issues promptly.
+4. Document and communicate the steps to resolve common import issues to the team.

--- a/Test_connection_functionality_risk.md
+++ b/Test_connection_functionality_risk.md
@@ -1,0 +1,33 @@
+### Risk Description
+
+**Title:** Test connection functionality for the toolkit may not work correctly.
+
+**Detailed Description:** There is a risk that the test connection functionality within the toolkit may not operate as expected. This could lead to incorrect test results, impacting the overall quality and reliability of the toolkit. The issue may arise due to various factors such as incorrect implementation, lack of proper testing, or unforeseen technical challenges.
+
+**Category:** Quality
+
+**Trigger:** Technology
+
+**Likelihood:** Middle
+
+**Impact:** High
+
+**Responsible Person:** QA Lead
+
+**Treatment/Maintenance Plan:**
+1. Conduct a thorough review of the test connection functionality code.
+2. Implement additional test cases to cover edge scenarios.
+3. Perform regular code audits and peer reviews.
+4. Ensure comprehensive documentation of the test connection functionality.
+
+**Risk Strategy:** Mitigate
+
+**Mitigation Plan Actions:**
+1. Assign a dedicated team to investigate and resolve any issues with the test connection functionality.
+2. Schedule regular testing cycles to identify and address potential problems early.
+3. Provide training to the development team on best practices for implementing and testing connection functionalities.
+
+**Contingency Plan Actions:**
+1. Develop a backup test connection functionality that can be used in case the primary one fails.
+2. Establish a rapid response team to address any issues that arise in production.
+3. Communicate with stakeholders about potential risks and the steps being taken to mitigate them.


### PR DESCRIPTION
Added detailed risk description for the issue where new collections are not created under the Collections section post-import. This includes risk category, trigger, likelihood, impact, responsible person, treatment/maintenance plan, risk strategy, mitigation plan actions, and contingency plan actions.