### PR TITLE
Add Out of Scope section to test plan

### DIFF
--- a/Out_of_Scope.md
+++ b/Out_of_Scope.md
@@ -1,0 +1,32 @@
+**Out of Scope**
+
+**Introduction**
+The purpose of this section is to define the boundaries of the testing activities by clearly specifying what is not included in the scope of the testing effort.
+
+**Excluded Features/Functions**
+- Feature A: This feature will not be tested as it is not part of the current release.
+- Function B: This function is deprecated and will not be included in the testing scope.
+
+**Non-supported Platforms/Environments**
+- Platform X: Testing will not be conducted on Platform X as it is not supported by the application.
+- Environment Y: This environment is not part of the supported environments for this release.
+
+**External Systems**
+- Integration with System Z: The integration with System Z is not included in the testing scope for this release.
+
+**Data Exclusions**
+- Data from Source Q: Data originating from Source Q will not be included in the testing activities.
+- Specific Data Conditions: Data conditions such as edge cases for data type R will not be tested.
+
+**Phases/Stages Excluded**
+- Alpha Phase: Testing activities will not cover the Alpha phase of the project.
+- Maintenance Stage: The maintenance stage is out of scope for the current testing efforts.
+
+**Rationale**
+The above items are excluded from the testing scope due to various reasons such as non-relevance to the current release, lack of support, or being out of the project's current focus. This helps in prioritizing the testing efforts on the most critical and relevant areas.
+
+**Impact Analysis**
+The exclusion of these items may have potential impacts such as limited test coverage and potential undiscovered issues in the excluded areas. However, these impacts are considered acceptable given the current project priorities and constraints.
+
+**Approval**
+Stakeholders are required to review and approve the out-of-scope items to ensure alignment and understanding of the testing boundaries.

--- a/Project_Specific_Impact_to_Testing.md
+++ b/Project_Specific_Impact_to_Testing.md
@@ -1,0 +1,12 @@
+### Project Specific Impact to Testing
+
+| Section                  | Details                                                                                       |
+|--------------------------|-----------------------------------------------------------------------------------------------|
+| **Project Overview**     | This project aims to develop a new feature-rich web application to enhance user experience and increase engagement. The scope includes front-end development, back-end integration, and performance optimization.                       |
+| **Key Features and Requirements** | The project includes key features such as real-time data updates, user authentication, and third-party API integrations. These features will require extensive functional and integration testing. |
+| **Testing Challenges**   | The project introduces complexities such as handling real-time data, ensuring security for user authentication, and managing dependencies on third-party APIs. These challenges will require thorough testing strategies and robust test cases. |
+| **Resource Requirements**| Special resource requirements include access to real-time data environments, security testing tools, and skilled personnel for API testing and performance analysis. |
+| **Risk Assessment**      | Potential risks include data inconsistency, security vulnerabilities, and integration failures. Mitigation strategies involve comprehensive test coverage, regular security audits, and continuous integration practices.   |
+| **Timeline and Milestones** | Critical milestones include completion of front-end development by Q1, back-end integration by Q2, and full system testing by Q3. Timely achievement of these milestones is essential for the project's success. |
+| **Dependencies**         | Dependencies include third-party API availability, external data sources, and compliance with industry standards. Any changes or issues with these dependencies could impact the testing process. |
+| **Compliance and Standards** | The project must adhere to compliance requirements such as GDPR for data protection and industry standards for web application security. These standards will guide the testing process to ensure compliance. |

--- a/Scope_of_Testing.md
+++ b/Scope_of_Testing.md
@@ -1,0 +1,11 @@
+### Scope of Testing
+
+| Section            | Details                                                                 |
+|--------------------|-------------------------------------------------------------------------|
+| **Objectives**     | The primary objective of the testing effort is to ensure that the software product meets the specified requirements and functions correctly in all intended environments. The testing will aim to identify and resolve defects, verify that the product performs as expected, and validate that it meets user needs and business objectives.                    |
+| **In-Scope Items** | The following features, functionalities, and components will be tested: <br> - User authentication and authorization <br> - Data input and output validation <br> - User interface and user experience <br> - Integration with third-party services <br> - Performance under load <br> - Security vulnerabilities |
+| **Out-of-Scope Items** | The following features, functionalities, and components will not be tested: <br> - Legacy system compatibility <br> - Non-functional requirements not specified in the project scope <br> - Features planned for future releases |
+| **Test Types**     | The types of testing that will be performed include: <br> - Functional testing <br> - Performance testing <br> - Security testing <br> - Usability testing <br> - Regression testing |
+| **Test Levels**    | The levels of testing that will be covered include: <br> - Unit testing <br> - Integration testing <br> - System testing <br> - Acceptance testing |
+| **Assumptions**    | The following assumptions are made during the planning of the testing scope: <br> - All necessary test environments will be available and configured correctly <br> - Test data will be provided and will be representative of real-world scenarios <br> - Development team will fix identified defects in a timely manner |
+| **Constraints**    | The following constraints may impact the testing effort: <br> - Limited availability of test resources <br> - Tight project deadlines <br> - Dependencies on third-party services for integration testing |


### PR DESCRIPTION
This pull request adds the 'Out of Scope' section to the test plan, defining the boundaries of the testing activities by specifying what is not included in the scope of the testing effort.